### PR TITLE
Change the #\Bell character to #\Bel

### DIFF
--- a/terminal.lisp
+++ b/terminal.lisp
@@ -96,7 +96,7 @@
 
 (defmethod beep ((b terminal))
   (declare (ignore b))
-  (and (write-char #\Bell *error-output*)
+  (and (write-char #\Bel *error-output*)
        (force-output *error-output*)))
 
 (defmethod page ((backend terminal))


### PR DESCRIPTION
In recent versions of SBCL ([>=1.2.2](http://www.sbcl.org/all-news.html#1.2.2)), the character #\Bell produces a unicode bell character and does not ring the terminal bell, which is triggered by #\Bel.