### PR TITLE
Set editor-history on finish-input.

### DIFF
--- a/command-functions.lisp
+++ b/command-functions.lisp
@@ -74,6 +74,8 @@
 
 (defun finish-input (chord editor)
   (declare (ignore chord editor))
+  (setf (%buffer-next (editor-history editor)) nil
+        (%buffer-prev (editor-history editor)) (%buffer-list (editor-history editor)))
   (throw 'linedit-done t))
 
 ;;; CASE CHANGES


### PR DESCRIPTION
Linedit did not go through its editor-history correctly.

Small example of the problem:

  1) start SBCL with Linedit,
  2) eval "(+ 1 1)",
  3) eval "(+ 2 2)",
  4) go back one step into history to "(+ 2 2)",
  5) press enter to eval it again,
  6) go through history again, notice it is not correct anymore.